### PR TITLE
fix interceptor

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,6 @@ import { join } from 'path';
     {
       provide: APP_INTERCEPTOR,
       useClass: Interceptor,
-      scope: Scope.REQUEST
     },
   ],
 })

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -1,18 +1,30 @@
-import { CallHandler, ExecutionContext, Inject, Injectable, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
 
 @Injectable()
 export class Interceptor implements NestInterceptor {
   private internalMagicNumber: number;
+  private magicNumber: number;
 
   constructor(
-    @Inject(Symbol.for('MagicNumber'))
-    private readonly magicNumber: number,
+    private readonly modRef: ModuleRef,
   ) {
     this.internalMagicNumber = Math.random();
   }
 
-  intercept(context: ExecutionContext, next: CallHandler) {
+  async intercept(context: ExecutionContext, next: CallHandler) {
+    const contextId = ContextIdFactory.getByRequest(this.getRequest(context));
+    this.magicNumber = await this.modRef.resolve<number>(Symbol.for('MagicNumber'), contextId);
     console.log('Interceptor: ', this.magicNumber, this.internalMagicNumber);
     return next.handle();
+  }
+
+  getRequest(context: ExecutionContext) {
+    if (context.getType() === 'http') {
+      return context.switchToHttp().getRequest();
+    }
+    const gql = GqlExecutionContext.create(context);
+    return gql.getContext().req;
   }
 }


### PR DESCRIPTION
This is a working implementation for REST and GQL
using `ModuleRef` instead of relying on REQUEST
scoped interceptors. You need to make sure that
the gql context has req added to it (it does by
default for apollo-server-express, but being
explicit never hurt either). You can add that in
by doing

```ts
GraphQLModule.forRoot({
  context: ({ req }) => ({ req })
  // other options
})
```

This will allow for `gql.getContext().req`
to pull back the request object which is require
for `ContextIdFactory.getByRequest()`.

ref: [#5722](https://github.com/nestjs/nest/issues/5722)